### PR TITLE
Fixed excessive xp generation.

### DIFF
--- a/mods/adventuretest/register_functions.lua
+++ b/mods/adventuretest/register_functions.lua
@@ -65,9 +65,8 @@ local function adventuretest_dignode(pos, node, digger)
 	if dug % 100 == 0 then
 		local ppos = digger:getpos()
 		-- every 100 give them some experience
-		local multiplier = dug / 100
-		local exp = 5 * multiplier
-		local e = experience.exp_to_items(exp)
+		local xp = math.random(1, 5)
+		local e = experience.exp_to_items(xp)
 		for _,item in pairs(e) do
 			default.drop_item(ppos,item)
 		end
@@ -88,9 +87,8 @@ local function adventuretest_placenode(pos, node, placer)
 	  if placed % 100 == 0 then
 	  	local ppos = placer:getpos()
 	  	-- every 100 give them some experience
-	  	local multiplier = placed / 100
-	  	local exp = 5 * multiplier
-	  	local e = experience.exp_to_items(exp)
+		local xp = math.random(1, 5)
+		local e = experience.exp_to_items(xp)
 	  	for _,item in pairs(e) do
 	  		default.drop_item(ppos,item)
 	  	end


### PR DESCRIPTION
Awarding 5 xp for every 100 blocks the player ever dug or placed, is shurly not what you intended. 
For example if the player dug 1000 stone that will result in 50 xp. At 1100, 55 xp and so on. 
Mining with an bronze pick let's you easily dig 10,000 stone in one afternoon (this is what i did) resulting in 25,250 xp.

The changes will award the player with an average of 2.5 xp per 100 blocks.
