### PR TITLE
Using register_lbm to update nodes which existed prior to SHIFT-CLICK formspec

### DIFF
--- a/mods/affects/chatcommands.lua
+++ b/mods/affects/chatcommands.lua
@@ -5,7 +5,9 @@ minetest.register_chatcommand("affect",{
 	privs = {affects=true},
 	func = function (name, param)
 		local aname, affectid = string.match(param, "([^ ]+) (.+)")	
-		if ( affects.affectPlayer(aname,affectid) ) then
+		if ( aname == nil or aname == "" or affectid == nil or affectid == '' ) then
+			minetest.chat_send_player(name, "Syntax: affect <name> <affectid>")
+		elseif ( affects.affectPlayer(aname,affectid) ) then
 			minetest.chat_send_player(name,aname.." has been affected by "..affects._affects[affectid].name)
 		else
 			minetest.chat_send_player(name,"Unable to affect "..aname.." with "..affectid)
@@ -15,11 +17,13 @@ minetest.register_chatcommand("affect",{
 
 minetest.register_chatcommand("removeaffect",{
 	params = "<name> [affectid]",
-	description = "Removes and affect or all affects from a player",
+	description = "Remove an affect or all affects from a player",
 	privs = {affects=true},
 	func = function (name, param)
 		local aname, affectid = string.match(param, "([^ ]+) (.+)")	
-		if ( affects.removeAffect(aname,affectid) ) then
+		if ( aname == nil or aname == "" ) then
+			minetest.chat_send_player(name, "Syntax: removeaffect <name> [affectid]")
+		elseif ( affects.removeAffect(aname,affectid) ) then
 			minetest.chat_send_player(name,"Affect removed from "..aname)
 		else
 			minetest.chat_send_player(name,"Unable to remove affects")

--- a/mods/cottages/nodes_anvil.lua
+++ b/mods/cottages/nodes_anvil.lua
@@ -46,8 +46,8 @@ local cottages_anvil_formspec =
 					"label[0,3.0;"..S("Punch anvil with hammer to").."]"..
 					"label[0,3.3;"..S("repair tool in workpiece-slot.").."]"..
                                 "list[current_player;main;0,4;8,4;]"
-				.."listring[current_player;main]".."listring[current_name;hammer]"
 				.."listring[current_player;main]".."listring[current_name;input]"
+				.."listring[current_player;main]".."listring[current_name;hammer]"
 
 
 minetest.register_node("cottages:anvil", {
@@ -301,5 +301,20 @@ minetest.register_craft({
                 {cottages.craftitem_steel,cottages.craftitem_steel,cottages.craftitem_steel},
                 {cottages.craftitem_steel,cottages.craftitem_steel,cottages.craftitem_steel},
                 {'',                   cottages.craftitem_stick,      ''                   } }
+})
+
+--------------------------------------------------------------------------------
+-- Update existing nodes to use SHIFT-CLICK
+--------------------------------------------------------------------------------
+minetest.register_lbm({
+        name = "cottages:anvil_lbm",
+        nodenames = {"cottages:anvil"},
+        run_at_every_load = false,
+        action = function(pos, node)
+                local meta = minetest.get_meta(pos)
+		meta:set_string("formspec",
+				cottages_anvil_formspec..
+				"label[2.5,-0.5;"..S("Owner: %s"):format(meta:get_string('owner') or "").."]");
+        end,
 })
 

--- a/mods/cottages/nodes_barrel.lua
+++ b/mods/cottages/nodes_barrel.lua
@@ -25,25 +25,25 @@ local S = cottages.S
 
 barrel = {};
 
+local barrel_formspec = "size[8,9]"..
+			"image[2.6,2;2,3;default_sandstone.png^[lowpart:"..
+			-- (100-percent)..":default_desert_stone.png]".. -- TODO: better images
+			"50:default_desert_stone.png]".. -- TODO: better images
+			"label[2.2,0;"..S("Pour:").."]"..
+			"list[current_name;input;3,0.5;1,1;]"..
+			"label[5,3.3;"..S("Fill:").."]"..
+			"list[current_name;output;5,3.8;1,1;]"..
+			"list[current_player;main;0,5;8,4;]"
+			.."listring[current_name;output]".."listring[current_player;main]"
+			.."listring[current_name;input]".."listring[current_player;main]"
+
 -- prepare formspec
 barrel.on_construct = function( pos )
 
    local meta = minetest.get_meta(pos);
    local percent = math.random( 1, 100 ); -- TODO: show real filling
 
-   meta:set_string( 'formspec', 
-                               "size[8,9]"..
-                                "image[2.6,2;2,3;default_sandstone.png^[lowpart:"..
-                                                (100-percent)..":default_desert_stone.png]".. -- TODO: better images
-                                "label[2.2,0;"..S("Pour:").."]"..
-                                "list[current_name;input;3,0.5;1,1;]"..
-                                "label[5,3.3;"..S("Fill:").."]"..
-                                "list[current_name;output;5,3.8;1,1;]"..
-                                "list[current_player;main;0,5;8,4;]"
-				.."listring[current_name;output]".."listring[current_player;main]"
-				.."listring[current_name;input]".."listring[current_player;main]"
-		)
-
+   meta:set_string( 'formspec', barrel_formspec)
 
    meta:set_string( 'liquid_type', '' ); -- which liquid is in the barrel?
    meta:set_int(    'liquid_level', 0 ); -- how much of the liquid is in there?
@@ -223,3 +223,17 @@ minetest.register_craft({
 		{"cottages:tub"},
 	},
 })
+
+--------------------------------------------------------------------------------
+-- Update existing nodes to use SHIFT-CLICK
+--------------------------------------------------------------------------------
+minetest.register_lbm({
+        name = "cottages:barrel_lbm",
+        nodenames = {"cottages:barrel"},
+        run_at_every_load = false,
+        action = function(pos, node)
+                local meta = minetest.get_meta(pos)
+		meta:set_string("formspec", barrel_formspec)
+        end,
+})
+

--- a/mods/cottages/nodes_chests.lua
+++ b/mods/cottages/nodes_chests.lua
@@ -59,3 +59,16 @@ minetest.register_node("cottages:chest_storage", {
 	is_ground_content = false,
 })
 
+--------------------------------------------------------------------------------
+-- Update existing nodes to use SHIFT-CLICK
+--------------------------------------------------------------------------------
+minetest.register_lbm({
+        name = "cottages:chests_lbm",
+        nodenames = {"cottages:chest_private", "cottages:chest_work", "cottages:chest_storage"},
+        run_at_every_load = false,
+        action = function(pos, node)
+                local meta = minetest.get_meta(pos)
+		meta:set_string("formspec", default.chest_formspec)
+        end,
+})
+

--- a/mods/cottages/nodes_furniture.lua
+++ b/mods/cottages/nodes_furniture.lua
@@ -189,6 +189,12 @@ end
 
 minetest.register_node("cottages:table", cottages_table_def );
 
+local cottage_shelf_formspec =
+		"size[8,8]"..
+		"list[current_name;main;0,0;8,3;]"..
+		"list[current_player;main;0,4;8,4;]"..
+		"listring[]"
+
 -- looks better than two slabs impersonating a shelf; also more 3d than a bookshelf 
 -- the infotext shows if it's empty or not
 minetest.register_node("cottages:shelf", {
@@ -221,11 +227,7 @@ minetest.register_node("cottages:shelf", {
 
                 	local meta = minetest.get_meta(pos);
 
-	                meta:set_string("formspec",
-                                "size[8,8]"..
-                                "list[current_name;main;0,0;8,3;]"..
-                                "list[current_player;main;0,4;8,4;]"..
-				"listring[current_name;main]".."listring[current_player;main]")
+	                meta:set_string("formspec", cottage_shelf_formspec)
                 	meta:set_string("infotext", S("open storage shelf"))
                 	local inv = meta:get_inventory();
                 	inv:set_size("main", 24);
@@ -388,5 +390,18 @@ minetest.register_craft({
 	recipe = {
 		{cottages.craftitem_steel, '', cottages.craftitem_steel},
 	}
+})
+
+--------------------------------------------------------------------------------
+-- Update existing nodes to use SHIFT-CLICK
+--------------------------------------------------------------------------------
+minetest.register_lbm({
+        name = "cottages:shelf_lbm",
+        nodenames = {"cottages:shelf"},
+        run_at_every_load = false,
+        action = function(pos, node)
+                local meta = minetest.get_meta(pos)
+		meta:set_string("formspec", cottage_shelf_formspec)
+        end,
 })
 

--- a/mods/cottages/nodes_straw.lua
+++ b/mods/cottages/nodes_straw.lua
@@ -99,8 +99,8 @@ local cottages_formspec_treshing_floor =
 					"label[0,3.0;"..S("to get straw and seeds from wheat.").."]"..
                                 "list[current_player;main;0,4;8,4;]"
 				.."listring[current_name;straw]".."listring[current_player;main]"
-				.."listring[current_name;seeds]".."listring[current_player;main]"
 				.."listring[current_name;harvest]".."listring[current_player;main]"
+				.."listring[current_name;seeds]".."listring[current_player;main]"
 
 minetest.register_node("cottages:threshing_floor", {
 	drawtype = "nodebox",
@@ -576,3 +576,31 @@ minetest.register_craft({
 		{"cottages:straw","cottages:straw","cottages:straw"},
 	},
 })
+
+--------------------------------------------------------------------------------
+-- Update existing nodes to use SHIFT-CLICK
+--------------------------------------------------------------------------------
+minetest.register_lbm({
+        name = "cottages:threshing_floor_lbm",
+        nodenames = {"cottages:threshing_floor"},
+        run_at_every_load = false,
+        action = function(pos, node)
+                local meta = minetest.get_meta(pos)
+		meta:set_string("formspec",
+				cottages_formspec_treshing_floor..
+				"label[2.5,-0.5;"..S("Owner: %s"):format(meta:get_string('owner') or "").."]" );
+        end,
+})
+
+minetest.register_lbm({
+        name = "cottages:handmill_lbm",
+        nodenames = {"cottages:handmill"},
+        run_at_every_load = false,
+        action = function(pos, node)
+                local meta = minetest.get_meta(pos)
+		meta:set_string("formspec",
+				cottages_handmill_formspec..
+				"label[2.5,-0.5;"..S("Owner: %s"):format(meta:get_string('owner') or "").."]" );
+        end,
+})
+

--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -925,6 +925,19 @@ minetest.register_abm({
 	end, 
 })
 
+--------------------------------------------------------------------------------
+-- Update existing nodes to use SHIFT-CLICK
+--------------------------------------------------------------------------------
+minetest.register_lbm({
+	name = "default:chest_lbm",
+	nodenames = {"default:chest", "default:npc_chest"},
+	run_at_every_load = false,
+	action = function(pos, node)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("formspec",default.chest_formspec)
+	end,
+})
+
 
 local function has_locked_chest_privilege(meta, player)
 	if meta ~= nil then


### PR DESCRIPTION
Update to modify old nodes (with formspecs without SHIFT-CLICK) to ones which support SHIFT-CLICK.

Also noticed a crash when using chat commands "affect"/"removeaffect".
